### PR TITLE
Fix 'link' command and make 'update' consistent with the rest

### DIFF
--- a/src/yalc.ts
+++ b/src/yalc.ts
@@ -86,7 +86,7 @@ const argv = yargs
     }
   })
   .command({
-    command: 'link ',
+    command: 'link',
     describe: 'Link package from yalc repo to the project',
     builder: () => {
       return yargs
@@ -101,7 +101,7 @@ const argv = yargs
     }
   })
   .command({
-    command: ['update'],
+    command: 'update',
     describe: 'Update packages from yalc repo',
     builder: () => {
       return yargs        


### PR DESCRIPTION
`yalc link` wasn't finding its list of packages; somehow the extra space at the end caused `yargs` to eat the rest of the command line.

While looking for similar issues in the other commands I saw that `update` was in an array; there's no obvious reason for it, and it works with the plain string value, so I made it consistent with the other command definitions.