### PR TITLE
Run 'prepublishOnly' script during 'yalc publish'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export interface PackageManifest {
     preinstall?: string,
     install?: string,
     prepublish?: string
+    prepublishOnly?: string
     postpublish?: string
     preyalc?: string
     postyalc?: string

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -70,6 +70,9 @@ export const publishPackage = async (options: PublishPackageOptions) => {
     if (pkg.scripts!.preyalc) {
       console.log('Running preloc script: ' + pkg.scripts!.preyalc)
       execSync(scriptRunCmd + values.prescript, execLoudOptions)
+    } else if (pkg.scripts!.prepublishOnly) {
+      console.log('Running prepublishOnly script: ' + pkg.scripts!.prepublishOnly)
+      execSync(scriptRunCmd + 'prepublishOnly', execLoudOptions)
     } else if (pkg.scripts!.prepublish) {
       console.log('Running prepublish script: ' + pkg.scripts!.prepublish)
       execSync(scriptRunCmd + 'prepublish', execLoudOptions)


### PR DESCRIPTION
I've switched from `prepublish` to `prepublishOnly` scripts.  It would be nice if yalc ran `prepublishOnly` before publishing.