### PR TITLE
validate generated signature across test run instead of against checked in hash

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -148,8 +148,12 @@ describe('Yalc package manager', () => {
 
     })
 
-    const expectedSignature = fs.readFileSync(join(publishedPackagePath, 'yalc.sig')).toString();
     describe('signature consistency', () => {
+      let expectedSignature: string;
+      before(() => {
+        expectedSignature = fs.readFileSync(join(publishedPackagePath, 'yalc.sig')).toString();
+      })
+
       beforeEach((done) => {
         publishPackage({
           workingDir: depPackageDir,


### PR DESCRIPTION
Tests were failing on my win10 machine because the hash generated did not match the checked in version. This change changes the tests to just validate  hash consistency across the test run.