### PR TITLE
add repository link to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "yalc",
   "version": "1.0.0-pre.22",
   "description": "Work yarn packages locally like a boss.",
+  "homepage": "https://github.com/whitecolor/yalc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/whitecolor/yalc.git"
+  },
   "bin": {
     "yalc": "src/yalc.js"
   },


### PR DESCRIPTION
This just adds the repo link to the package.json file. This is useful so that the package page on npmjs.com has a clickable link to this Github repo.