### PR TITLE
add tslint hanging promise detection and fix errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "precommit": "yalc check",
     "_prepush": "yarn test",
     "prepublishOnly": "tsc && yarn test",
-    "test": "mocha test",
+    "test": "mocha test && yarn lint",
     "watch": "mocha test --watch",
-    "ci": "tsc && yarn test"
+    "ci": "tsc && yarn test",
+    "lint": "tslint -p ."
   },
   "license": "MIT",
   "dependencies": {
@@ -43,6 +44,7 @@
     "husky": "^0.13.3",
     "mocha": "^3.2.0",
     "ts-clean-built": "^1.0.0",
+    "tslint": "^5.11.0",
     "typescript": "2.6.1-insiders.20171016"
   }
 }

--- a/src/add.ts
+++ b/src/add.ts
@@ -58,7 +58,7 @@ const isSymlink = (path: string) => {
   }
 }
 
-export const addPackages = (packages: string[], options: AddPackagesOptions) => {
+export const addPackages = async (packages: string[], options: AddPackagesOptions) => {
   const workingDir = options.workingDir
   const localPkg = readPackageManifest(workingDir)
   let localPkgUpdated = false
@@ -171,7 +171,7 @@ export const addPackages = (packages: string[], options: AddPackagesOptions) => 
       })), { workingDir: options.workingDir }
   )
 
-  addInstallations(addedInstalls)
+  await addInstallations(addedInstalls)
 
   if (options.yarn) {
     const changeDirCmd = 'cd ' + options.workingDir + ' && '

--- a/src/installations.ts
+++ b/src/installations.ts
@@ -34,14 +34,14 @@ export const readInstallationsFile = (): InstallationsFile => {
   return installationsConfig
 }
 
-export const saveInstallationsFile = (installationsConfig: InstallationsFile) => {
+export const saveInstallationsFile = async (installationsConfig: InstallationsFile) => {
   const storeDir = getStoreMainDir()
   const installationFilePath = path.join(storeDir, values.installationsFile)
   const data = JSON.stringify(installationsConfig, null, 2)
   return fs.writeFile(installationFilePath, data)
 }
 
-export const addInstallations = (installations: (PackageInstallation)[]) => {
+export const addInstallations = async (installations: (PackageInstallation)[]) => {
   const installationsConfig = readInstallationsFile()
   let updated = false
   installations
@@ -57,11 +57,11 @@ export const addInstallations = (installations: (PackageInstallation)[]) => {
     })
 
   if (updated) {
-    saveInstallationsFile(installationsConfig)
+    await saveInstallationsFile(installationsConfig)
   }
 }
 
-export const removeInstallations = (installations: (PackageInstallation)[]) => {
+export const removeInstallations = async (installations: (PackageInstallation)[]) => {
   const installationsConfig = readInstallationsFile()
   let updated = false
   installations
@@ -77,6 +77,6 @@ export const removeInstallations = (installations: (PackageInstallation)[]) => {
       }
     })
   if (updated) {
-    saveInstallationsFile(installationsConfig)
+    await saveInstallationsFile(installationsConfig)
   }
 }

--- a/src/lockfile.ts
+++ b/src/lockfile.ts
@@ -82,15 +82,24 @@ export const writeLockfile = (lockfile: LockFileConfig, options: { workingDir: s
 
 export const addPackageToLockfile = (
   packages: ({ name: string } & LockFilePackageEntry)[],
-  options: { workingDir: string }) => {
+  options: { workingDir: string }
+) => {
   const lockfile = readLockfile(options)
   packages.forEach(({ name, version, file, link, replaced, signature }) => {
     let old = lockfile.packages[name] || {}
     lockfile.packages[name] = {}
-    version && (lockfile.packages[name].version = version)
-    signature && (lockfile.packages[name].signature = signature)
-    file && (lockfile.packages[name].file = true)
-    link && (lockfile.packages[name].link = true)
+    if (version) {
+      lockfile.packages[name].version = version
+    }
+    if (signature) {
+      lockfile.packages[name].signature = signature
+    }
+    if (file) {
+      lockfile.packages[name].file = true
+    }
+    if (link) {
+      lockfile.packages[name].link = true
+    }
     if (replaced || old.replaced) {
       lockfile.packages[name].replaced = replaced || old.replaced
     }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -88,15 +88,16 @@ export const publishPackage = async (options: PublishPackageOptions) => {
     const installationPaths =
       installationsConfig[pkg.name] || []
     const installationsToRemove: PackageInstallation[] = []
-    installationPaths.forEach((workingDir) => {
+    for (const workingDir in installationPaths) {
       console.log(`Pushing ${pkg.name}@${pkg.version} in ${workingDir}`)
+      const installationsToRemoveForPkg = await updatePackages([pkg.name], { workingDir, noInstallationsRemove: true });
       installationsToRemove.concat(
-        updatePackages([pkg.name], { workingDir, noInstallationsRemove: true })
+        installationsToRemoveForPkg
       )
-    })
-    removeInstallations(installationsToRemove)
+    }
+    await removeInstallations(installationsToRemove)
   }  
-  workaroundYarnCacheBug(pkg)
+  await workaroundYarnCacheBug(pkg)
   const publishedPackageDir = join(getStorePackagesDir(), pkg.name, pkg.version)
   const publishedPkg = readPackageManifest(publishedPackageDir)!
   console.log(`${publishedPkg.name}@${publishedPkg.version} published in store.`)

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -33,7 +33,7 @@ const isYalcFileAddress = (
   return regExp.test(address)
 }
 
-export const removePackages = (packages: string[], options: RemovePackagesOptions) => {
+export const removePackages = async (packages: string[], options: RemovePackagesOptions) => {
   const { workingDir } = options
   const lockFileConfig = readLockfile({ workingDir: workingDir })
   const pkg = readPackageManifest(workingDir)
@@ -116,6 +116,6 @@ export const removePackages = (packages: string[], options: RemovePackagesOption
   })
 
   if (!options.retreat) {
-    removeInstallations(installationsToRemove)
+    await removeInstallations(installationsToRemove)
   }
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -17,7 +17,7 @@ export interface UpdatePackagesOptions {
   noInstallationsRemove?: boolean,
   workingDir: string,
 }
-export const updatePackages = (packages: string[], options: UpdatePackagesOptions) => {
+export const updatePackages = async (packages: string[], options: UpdatePackagesOptions) => {
   const lockfile = readLockfile({ workingDir: options.workingDir })
 
   let packagesToUpdate: string[] = []
@@ -51,18 +51,18 @@ export const updatePackages = (packages: string[], options: UpdatePackagesOption
   
   const packagesFiles = lockPackages
     .filter(p => p.file).map(p => p.name)
-  addPackages(packagesFiles, { workingDir: options.workingDir })
+  await addPackages(packagesFiles, { workingDir: options.workingDir })
 
   const packagesLinks = lockPackages
     .filter(p => !p.file && !p.link).map(p => p.name)
-  addPackages(packagesLinks, { workingDir: options.workingDir, link: true })
+    await addPackages(packagesLinks, { workingDir: options.workingDir, link: true })
 
   const packagesLinkDep = lockPackages
     .filter(p => p.link).map(p => p.name)
-  addPackages(packagesLinkDep, { workingDir: options.workingDir, linkDep: true })
+    await addPackages(packagesLinkDep, { workingDir: options.workingDir, linkDep: true })
 
   if (!options.noInstallationsRemove) {
-    removeInstallations(installationsToRemove)
+    await removeInstallations(installationsToRemove)
   }
   return installationsToRemove
 }

--- a/src/yalc.ts
+++ b/src/yalc.ts
@@ -15,6 +15,7 @@ import {
 
 const cliCommand = values.myNameIs
 
+// tslint:disable-next-line:no-unused-expression
 yargs
   .usage(cliCommand + ' [command] [options] [package1 [package2...]]')  
   .command({
@@ -37,7 +38,7 @@ yargs
     },
     handler: (argv) => {
       const folder = argv._[1]
-      publishPackage({
+      return publishPackage({
         workingDir: join(process.cwd(), folder || ''),
         force: argv.force,
         knit: argv.knit,
@@ -57,7 +58,7 @@ yargs
         .boolean(['knit', 'safe', 'force', 'sig'])
     },
     handler: (argv) => {
-      publishPackage({
+      return publishPackage({
         workingDir: join(process.cwd(), argv._[1] || ''),
         force: argv.force !== undefined ? argv.force : true,
         knit: argv.knit,
@@ -77,7 +78,7 @@ yargs
         .help(true)
     },
     handler: (argv) => {
-      addPackages(argv._.slice(1), {
+      return addPackages(argv._.slice(1), {
         dev: argv.dev || argv.saveDev,
         yarn: argv.yarn,
         linkDep: argv.link,
@@ -94,7 +95,7 @@ yargs
         .help(true)
     },
     handler: (argv) => {
-      addPackages(argv._.slice(1), {
+      return addPackages(argv._.slice(1), {
         link: true,
         workingDir: process.cwd()
       })
@@ -108,7 +109,7 @@ yargs
         .help(true)
     },
     handler: (argv) => {
-      updatePackages(argv._.slice(1), {
+      return updatePackages(argv._.slice(1), {
         workingDir: process.cwd()
       })
     }
@@ -122,7 +123,7 @@ yargs
         .help(true)
     },
     handler: (argv) => {
-      removePackages(argv._.slice(1), {
+      return removePackages(argv._.slice(1), {
         retreat: argv.retreat,
         workingDir: process.cwd(),
         all: argv.all
@@ -138,7 +139,7 @@ yargs
         .help(true)
     },
     handler: (argv) => {
-      removePackages(argv._.slice(1), {
+      return removePackages(argv._.slice(1), {
         all: argv.all,
         retreat: true,
         workingDir: process.cwd()

--- a/test/index.ts
+++ b/test/index.ts
@@ -76,12 +76,11 @@ describe('Yalc package manager', () => {
   })
   describe('Package publish', () => {
 
-    before((done) => {
-      publishPackage({
+    before(() => {
+      return publishPackage({
         workingDir: depPackageDir,
         signature: true
       })
-      setTimeout(done, 500)
     })
 
     it('publishes package to store', () => {
@@ -152,12 +151,11 @@ describe('Yalc package manager', () => {
         expectedSignature = fs.readFileSync(join(publishedPackagePath, 'yalc.sig')).toString();
       })
 
-      beforeEach((done) => {
-        publishPackage({
+      beforeEach(() => {
+        return publishPackage({
           workingDir: depPackageDir,
           signature: true
         })
-        setTimeout(done, 500)
       })
 
       for (let tries = 1; tries <= 5; tries++) {
@@ -176,9 +174,8 @@ describe('Yalc package manager', () => {
       join(publishedPackage2Path, 'file.txt')
 
     const originalFilePath = join(depPackage2Dir, 'file.txt')
-    before((done) => {
-      publishPackage({ workingDir: depPackage2Dir, knit: false })
-      setTimeout(done, 500)
+    before(() => {
+      return publishPackage({ workingDir: depPackage2Dir, knit: false })
     })
 
     it('publishes package to store', () => {
@@ -192,11 +189,10 @@ describe('Yalc package manager', () => {
   })
 
   describe('Add package', () => {
-    before((done) => {
-      addPackages([values.depPackage], {
+    before(() => {
+      return addPackages([values.depPackage], {
         workingDir: projectDir
       })
-      setTimeout(done, 500)
     })
     it('copies package to .yalc folder', () => {
       checkExists(join(projectDir, '.yalc', values.depPackage))
@@ -234,12 +230,11 @@ describe('Yalc package manager', () => {
   describe('Update package', () => {
     const innterNodeModulesFile =
       join(projectDir, 'node_modules', values.depPackage, 'node_modules/file.txt')
-    before((done) => {
+    before(() => {
       fs.ensureFileSync(innterNodeModulesFile)
-      updatePackages([values.depPackage], {
+      return updatePackages([values.depPackage], {
         workingDir: projectDir
       })
-      setTimeout(done, 500)
     })
 
     it('does not change yalc.lock', () => {
@@ -259,11 +254,10 @@ describe('Yalc package manager', () => {
   })
 
   describe('Remove not existing package', () => {
-    before((done) => {
-      removePackages(['xxxx'], {
+    before(() => {
+      return removePackages(['xxxx'], {
         workingDir: projectDir
       })
-      setTimeout(done, 500)
     })
     it('does not updates yalc.lock', () => {
       const lockFile = readLockfile({ workingDir: projectDir })
@@ -278,12 +272,11 @@ describe('Yalc package manager', () => {
   })
 
   describe('Reatreat package', () => {
-    before((done) => {
-      removePackages([values.depPackage], {
+    before(() => {
+      return removePackages([values.depPackage], {
         workingDir: projectDir,
         retreat: true
       })
-      setTimeout(done, 500)
     })
 
     it('does not updates yalc.lock', () => {
@@ -321,11 +314,10 @@ describe('Yalc package manager', () => {
   })
 
   describe('Update (restore after retreat) package', () => {
-    before((done) => {
-      updatePackages([values.depPackage], {
+    before(() => {
+      return updatePackages([values.depPackage], {
         workingDir: projectDir
       })
-      setTimeout(done, 500)
     })
 
     it('updates package.json', () => {
@@ -337,11 +329,10 @@ describe('Yalc package manager', () => {
   })
 
   describe('Remove package', () => {
-    before((done) => {
-      removePackages([values.depPackage], {
+    before(() => {
+      return removePackages([values.depPackage], {
         workingDir: projectDir
       })
-      setTimeout(done, 500)
     })
 
     it('updates yalc.lock', () => {
@@ -373,12 +364,11 @@ describe('Yalc package manager', () => {
   })
 
   describe('Add package (--link)', () => {
-    before((done) => {
-      addPackages([values.depPackage], {
+    before(() => {
+      return addPackages([values.depPackage], {
         workingDir: projectDir,
         linkDep: true
       })
-      setTimeout(done, 500)
     })
     it('copies package to .yalc folder', () => {
       checkExists(join(projectDir, '.yalc', values.depPackage))
@@ -414,11 +404,10 @@ describe('Yalc package manager', () => {
   })
 
   describe('Updated linked (--link) package', () => {
-    before((done) => {
-      updatePackages([values.depPackage], {
+    before(() => {
+      return updatePackages([values.depPackage], {
         workingDir: projectDir        
       })
-      setTimeout(done, 500)
     })    
     it('places yalc.lock correct info about file', () => {
       const lockFile = readLockfile({ workingDir: projectDir })

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-floating-promises": true,
+    "no-unused-expression": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,6 +51,18 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  dependencies:
+    sprintf-js "~1.0.2"
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -68,6 +80,14 @@ arrify@^1.0.0:
 async@~0.1.22:
   version "0.1.22"
   resolved "https://registry.yarnpkg.com/async/-/async-0.1.22.tgz#0fc1aaa088a0e3ef0ebe2d8831bab0dcf8845061"
+
+babel-code-frame@^6.22.0:
+  version "6.26.0"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
 
 balanced-match@^0.4.1:
   version "0.4.2"
@@ -95,7 +115,7 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -112,6 +132,14 @@ chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^2.3.0:
+  version "2.4.1"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 ci-info@^1.0.0:
   version "1.0.0"
@@ -139,6 +167,16 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+color-convert@^1.9.0:
+  version "1.9.2"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
+  dependencies:
+    color-name "1.1.1"
+
+color-name@1.1.1:
+  version "1.1.1"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
+
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -151,6 +189,10 @@ commander@2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@^2.12.1:
+  version "2.17.1"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -188,6 +230,10 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
+diff@^3.2.0:
+  version "3.5.0"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
 du@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/du/-/du-0.1.0.tgz#f26e340a09c7bc5b6fd69af6dbadea60fa8c6f4d"
@@ -200,9 +246,17 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+
+esutils@^2.0.2:
+  version "2.0.2"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
 find-parent-dir@^0.3.0:
   version "0.3.0"
@@ -310,6 +364,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 hosted-git-info@^2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
@@ -383,6 +441,17 @@ is-path-inside@^1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+js-yaml@^3.7.0:
+  version "3.12.0"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 json3@3.3.2:
   version "3.3.2"
@@ -469,7 +538,7 @@ map-limit@0.0.1:
   dependencies:
     once "~1.3.0"
 
-minimatch@^3.0.0:
+minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -578,6 +647,10 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
+path-parse@^1.0.5:
+  version "1.0.6"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -645,6 +718,12 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+resolve@^1.3.2:
+  version "1.8.1"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
+  dependencies:
+    path-parse "^1.0.5"
+
 rimraf@2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
@@ -660,6 +739,10 @@ rimraf@^2.2.8:
 "semver@2 || 3 || 4 || 5":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@^5.3.0:
+  version "5.5.1"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -678,6 +761,10 @@ spdx-expression-parse@~1.0.0:
 spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
@@ -709,6 +796,12 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  dependencies:
+    has-flag "^3.0.0"
+
 ts-clean-built@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ts-clean-built/-/ts-clean-built-1.0.0.tgz#474a71a58c8675d0ba867d8e6b8f595aab73ba6c"
@@ -716,9 +809,32 @@ ts-clean-built@^1.0.0:
     del "^2.2.2"
     minimist "^1.2.0"
 
-"ts-node@link:.yalc/ts-node":
-  version "0.0.0"
-  uid ""
+tslib@^1.8.0, tslib@^1.8.1:
+  version "1.9.3"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
+tslint@^5.11.0:
+  version "5.11.0"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    js-yaml "^3.7.0"
+    minimatch "^3.0.4"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
+    tsutils "^2.27.2"
+
+tsutils@^2.27.2:
+  version "2.29.0"
+  resolved "http://artifactory/artifactory/api/npm/tab-npm/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  dependencies:
+    tslib "^1.8.1"
 
 typescript@2.6.1-insiders.20171016:
   version "2.6.1-insiders.20171016"


### PR DESCRIPTION
This removes the need for the tests to wait using a set timeout after calling any of the yalc functions. Also will help prevent any future subtle async bugs around timing

attempt 2 at this, debugging the CI