### PR TITLE
Make 'push' safe to use with watch scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "del": "^2.2.2",
-    "fs-extra": "^4.0.2",
+    "fs-extra": "^7.0.1",
     "graceful-fs": "^4.1.15",
     "ignore": "^5.0.4",
     "npm-packlist": "^1.1.12",
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/del": "^2.2.32",
-    "@types/fs-extra": "^4.0.2",
+    "@types/fs-extra": "^5.0.4",
     "@types/glob": "^5.0.30",
     "@types/klaw": "^1.3.2",
     "@types/mocha": "^2.2.40",

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "clean-ts-built": "^1.0.0",
     "husky": "^0.13.3",
     "mocha": "^5.2.0",
-    "prettier": "^1.14.2",
+    "prettier": "^1.15.2",
     "trash-cli": "^1.4.0",
     "ts-clean-built": "^1.0.0",
     "tslint": "^5.11.0",
-    "tslint-config-prettier": "^1.15.0",
-    "tslint-plugin-prettier": "^1.3.0",
+    "tslint-config-prettier": "^1.16.0",
+    "tslint-plugin-prettier": "^2.0.1",
     "typescript": "^3.2.0-rc"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "del": "^2.2.2",
     "fs-extra": "^7.0.1",
-    "graceful-fs": "^4.1.15",
     "ignore": "^5.0.4",
     "npm-packlist": "^1.1.12",
     "user-home": "^2.0.0",

--- a/src/add.ts
+++ b/src/add.ts
@@ -176,7 +176,9 @@ export const addPackages = async (
         }
         const addedAction = options.link ? 'linked' : 'added'
         console.log(
-          `Package ${pkg.name}@${pkg.version} ${addedAction} ==> ${destModulesDir}.`
+          `Package ${pkg.name}@${
+            pkg.version
+          } ${addedAction} ==> ${destModulesDir}.`
         )
       }
 
@@ -213,6 +215,6 @@ export const addPackages = async (
 
   if (options.yarn) {
     console.log('Running yarn:')
-    execSync('yarn', {cwd: options.workingDir})
+    execSync('yarn', { cwd: options.workingDir })
   }
 }

--- a/src/add.ts
+++ b/src/add.ts
@@ -126,9 +126,6 @@ export const addPackages = async (
       }
       if (!doPure) {
         const destModulesDir = join(workingDir, 'node_modules', name)
-        if (options.link || options.linkDep || isSymlink(destModulesDir)) {
-          fs.removeSync(destModulesDir)
-        }
 
         if (options.link || options.linkDep) {
           ensureSymlinkSync(destYalcCopyDir, destModulesDir, 'junction')

--- a/src/add.ts
+++ b/src/add.ts
@@ -384,7 +384,9 @@ async function copyItems(
   items: FileSystemItem[]
 ): Promise<void> {
   const itemsToCopy = items.map(item =>
-    fs.copy(item.absolutePath, path.resolve(dirToCopyTo, item.relativePath))
+    fs.copy(item.absolutePath, path.resolve(dirToCopyTo, item.relativePath), {
+      preserveTimestamps: true
+    })
   )
   await Promise.all(itemsToCopy)
 }

--- a/src/add.ts
+++ b/src/add.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process'
 import * as fs from 'fs-extra'
 import { join } from 'path'
 import * as del from 'del'
-import { PackageInstallation, addInstallations } from './installations'
+import { addInstallations } from './installations'
 
 import { addPackageToLockfile } from './lockfile'
 
@@ -47,14 +47,6 @@ const emptyDirExcludeNodeModules = (path: string) => {
     cwd: path,
     ignore: '**/node_modules/**'
   })
-}
-
-const isSymlink = (path: string) => {
-  try {
-    return !!fs.readlinkSync(path)
-  } catch (e) {
-    return false
-  }
 }
 
 export const addPackages = async (

--- a/src/add.ts
+++ b/src/add.ts
@@ -50,6 +50,14 @@ const emptyDirExcludeNodeModules = (path: string) => {
   })
 }
 
+const isSymlink = (path: string) => {
+  try {
+    return !!fs.readlinkSync(path)
+  } catch (e) {
+    return false
+  }
+}
+
 export const addPackages = async (
   packages: string[],
   options: AddPackagesOptions
@@ -119,6 +127,10 @@ export const addPackages = async (
       if (options.link || options.linkDep) {
         ensureSymlinkSync(destYalcCopyDir, destModulesDir, 'junction')
       } else {
+        if (isSymlink(destModulesDir)) {
+          await fs.remove(destModulesDir)
+        }
+
         await replaceContentsOfDirectory(destModulesDir, destYalcCopyDir)
       }
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -235,19 +235,10 @@ async function replaceContentsOfDirectory(
     itemsInDestinationDirectoryExcludingNodeModulesDir
   )
 
-  const itemsInSourceDirectoryAsMap = convertFileSystemItemArrayToMapKeyedOnRelativePath(
-    itemsInSourceDirectoryExcludingNodeModulesDir
+  const { removedItems } = await findRemovedItems(
+    itemsInSourceDirectoryExcludingNodeModulesDir,
+    itemsInDestinationDirectoryExcludingNodeModulesDir
   )
-  const removedItems: FileSystemItem[] = []
-  for (const itemInDestinationDir of itemsInDestinationDirectoryExcludingNodeModulesDir) {
-    const itemInSourceDirectory = itemsInSourceDirectoryAsMap.get(
-      itemInDestinationDir.relativePath
-    )
-
-    if (itemInSourceDirectory === undefined) {
-      removedItems.push(itemInDestinationDir)
-    }
-  }
 
   await copyItems(destinationDirectory, newItems)
 
@@ -353,6 +344,27 @@ async function findNewAndChangedItems(
   }
 
   return { newItems, changedItems }
+}
+
+async function findRemovedItems(
+  sourceItems: FileSystemItem[],
+  destinationItems: FileSystemItem[]
+): Promise<{ removedItems: FileSystemItem[] }> {
+  const itemsInSourceDirectoryAsMap = convertFileSystemItemArrayToMapKeyedOnRelativePath(
+    sourceItems
+  )
+  const removedItems: FileSystemItem[] = []
+  for (const itemInDestinationDir of destinationItems) {
+    const itemInSourceDirectory = itemsInSourceDirectoryAsMap.get(
+      itemInDestinationDir.relativePath
+    )
+
+    if (itemInSourceDirectory === undefined) {
+      removedItems.push(itemInDestinationDir)
+    }
+  }
+
+  return { removedItems }
 }
 
 function convertFileSystemItemArrayToMapKeyedOnRelativePath(

--- a/src/add.ts
+++ b/src/add.ts
@@ -105,8 +105,7 @@ export const addPackages = async (
       }
       const destYalcCopyDir = join(workingDir, values.yalcPackagesFolder, name)
 
-      emptyDirExcludeNodeModules(destYalcCopyDir)
-      fs.copySync(storedPackageDir, destYalcCopyDir)
+      replaceContentsOfDir(destYalcCopyDir, storedPackageDir)
 
       let replacedVersion = ''
       if (doPure) {
@@ -134,8 +133,7 @@ export const addPackages = async (
         if (options.link || options.linkDep) {
           ensureSymlinkSync(destYalcCopyDir, destModulesDir, 'junction')
         } else {
-          emptyDirExcludeNodeModules(destModulesDir)
-          fs.copySync(destYalcCopyDir, destModulesDir)
+          replaceContentsOfDir(destModulesDir, destYalcCopyDir)
         }
 
         if (!options.link) {
@@ -217,4 +215,9 @@ export const addPackages = async (
     console.log('Running yarn:')
     execSync('yarn', { cwd: options.workingDir })
   }
+}
+
+function replaceContentsOfDir(dirToReplace: string, dirToCopyFrom: string) {
+  emptyDirExcludeNodeModules(dirToReplace)
+  fs.copySync(dirToCopyFrom, dirToReplace)
 }

--- a/src/add.ts
+++ b/src/add.ts
@@ -57,9 +57,6 @@ const isSymlink = (path: string) => {
   }
 }
 
-const gracefulFs = require('graceful-fs')
-gracefulFs.gracefulify(fs)
-
 export const addPackages = async (
   packages: string[],
   options: AddPackagesOptions

--- a/src/add.ts
+++ b/src/add.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra'
 import { join } from 'path'
 import * as del from 'del'
 import { addInstallations } from './installations'
+import * as path from 'path'
 
 import { addPackageToLockfile } from './lockfile'
 
@@ -61,120 +62,120 @@ export const addPackages = async (
   }
   const doPure =
     options.pure === false ? false : options.pure || !!localPkg.workspaces
-  const addedInstalls = packages
-    .map(packageName => {
-      const { name, version = '' } = parsePackageName(packageName)
+  const addedInstallsPromises = packages.map(async packageName => {
+    const { name, version = '' } = parsePackageName(packageName)
 
-      if (!name) {
-        console.log('Could not parse package name', packageName)
-      }
+    if (!name) {
+      console.log('Could not parse package name', packageName)
+    }
 
-      const storedPackagePath = getPackageStoreDir(name)
-      if (!fs.existsSync(storedPackagePath)) {
-        console.log(
-          `Could not find package \`${name}\` in store (${storedPackagePath}), skipping.`
-        )
-        return null
-      }
-      const versionToInstall = version || getLatestPackageVersion(name)
+    const storedPackagePath = getPackageStoreDir(name)
+    if (!fs.existsSync(storedPackagePath)) {
+      console.log(
+        `Could not find package \`${name}\` in store (${storedPackagePath}), skipping.`
+      )
+      return null
+    }
+    const versionToInstall = version || getLatestPackageVersion(name)
 
-      const storedPackageDir = getPackageStoreDir(name, versionToInstall)
+    const storedPackageDir = getPackageStoreDir(name, versionToInstall)
 
-      if (!fs.existsSync(storedPackageDir)) {
-        console.log(
-          `Could not find package \`${packageName}\` ` + storedPackageDir,
-          ', skipping.'
-        )
-        return null
-      }
+    if (!fs.existsSync(storedPackageDir)) {
+      console.log(
+        `Could not find package \`${packageName}\` ` + storedPackageDir,
+        ', skipping.'
+      )
+      return null
+    }
 
-      const pkg = readPackageManifest(storedPackageDir)
-      if (!pkg) {
-        return
-      }
-      const destYalcCopyDir = join(workingDir, values.yalcPackagesFolder, name)
+    const pkg = readPackageManifest(storedPackageDir)
+    if (!pkg) {
+      return
+    }
+    const destYalcCopyDir = join(workingDir, values.yalcPackagesFolder, name)
 
-      replaceContentsOfDir(destYalcCopyDir, storedPackageDir)
+    await replaceContentsOfDirectory(destYalcCopyDir, storedPackageDir)
 
-      let replacedVersion = ''
-      if (doPure) {
-        if (localPkg.workspaces) {
-          if (!options.pure) {
-            console.log(
-              'Because of `workspaces` enabled in this package,' +
-                ' --pure option will be used by default, to override use --no-pure.'
-            )
-          }
+    let replacedVersion = ''
+    if (doPure) {
+      if (localPkg.workspaces) {
+        if (!options.pure) {
+          console.log(
+            'Because of `workspaces` enabled in this package,' +
+              ' --pure option will be used by default, to override use --no-pure.'
+          )
         }
-        console.log(
-          `${pkg.name}@${pkg.version} added to ${join(
-            values.yalcPackagesFolder,
-            name
-          )} purely`
-        )
       }
-      if (!doPure) {
-        const destModulesDir = join(workingDir, 'node_modules', name)
+      console.log(
+        `${pkg.name}@${pkg.version} added to ${join(
+          values.yalcPackagesFolder,
+          name
+        )} purely`
+      )
+    }
+    if (!doPure) {
+      const destModulesDir = join(workingDir, 'node_modules', name)
 
-        if (options.link || options.linkDep) {
-          ensureSymlinkSync(destYalcCopyDir, destModulesDir, 'junction')
+      if (options.link || options.linkDep) {
+        ensureSymlinkSync(destYalcCopyDir, destModulesDir, 'junction')
+      } else {
+        await replaceContentsOfDirectory(destModulesDir, destYalcCopyDir)
+      }
+
+      if (!options.link) {
+        const protocol = options.linkDep ? 'link:' : 'file:'
+        const localAddress =
+          protocol + values.yalcPackagesFolder + '/' + pkg.name
+
+        const dependencies = localPkg.dependencies || {}
+        const devDependencies = localPkg.devDependencies || {}
+        let whereToAdd = options.dev ? devDependencies : dependencies
+
+        if (options.dev) {
+          if (dependencies[pkg.name]) {
+            replacedVersion = dependencies[pkg.name]
+            delete dependencies[pkg.name]
+          }
         } else {
-          replaceContentsOfDir(destModulesDir, destYalcCopyDir)
-        }
-
-        if (!options.link) {
-          const protocol = options.linkDep ? 'link:' : 'file:'
-          const localAddress =
-            protocol + values.yalcPackagesFolder + '/' + pkg.name
-
-          const dependencies = localPkg.dependencies || {}
-          const devDependencies = localPkg.devDependencies || {}
-          let whereToAdd = options.dev ? devDependencies : dependencies
-
-          if (options.dev) {
-            if (dependencies[pkg.name]) {
-              replacedVersion = dependencies[pkg.name]
-              delete dependencies[pkg.name]
-            }
-          } else {
-            if (!dependencies[pkg.name]) {
-              if (devDependencies[pkg.name]) {
-                whereToAdd = devDependencies
-              }
+          if (!dependencies[pkg.name]) {
+            if (devDependencies[pkg.name]) {
+              whereToAdd = devDependencies
             }
           }
-
-          if (whereToAdd[pkg.name] !== localAddress) {
-            replacedVersion = replacedVersion || whereToAdd[pkg.name]
-            whereToAdd[pkg.name] = localAddress
-            localPkg.dependencies =
-              whereToAdd === dependencies ? dependencies : localPkg.dependencies
-            localPkg.devDependencies =
-              whereToAdd === devDependencies
-                ? devDependencies
-                : localPkg.devDependencies
-            localPkgUpdated = true
-          }
-          replacedVersion =
-            replacedVersion == localAddress ? '' : replacedVersion
         }
-        const addedAction = options.link ? 'linked' : 'added'
-        console.log(
-          `Package ${pkg.name}@${
-            pkg.version
-          } ${addedAction} ==> ${destModulesDir}.`
-        )
-      }
 
-      const signature = readSignatureFile(storedPackageDir)
-      return {
-        signature,
-        name,
-        version,
-        replaced: replacedVersion,
-        path: options.workingDir
+        if (whereToAdd[pkg.name] !== localAddress) {
+          replacedVersion = replacedVersion || whereToAdd[pkg.name]
+          whereToAdd[pkg.name] = localAddress
+          localPkg.dependencies =
+            whereToAdd === dependencies ? dependencies : localPkg.dependencies
+          localPkg.devDependencies =
+            whereToAdd === devDependencies
+              ? devDependencies
+              : localPkg.devDependencies
+          localPkgUpdated = true
+        }
+        replacedVersion = replacedVersion == localAddress ? '' : replacedVersion
       }
-    })
+      const addedAction = options.link ? 'linked' : 'added'
+      console.log(
+        `Package ${pkg.name}@${
+          pkg.version
+        } ${addedAction} ==> ${destModulesDir}.`
+      )
+    }
+
+    const signature = readSignatureFile(storedPackageDir)
+    return {
+      signature,
+      name,
+      version,
+      replaced: replacedVersion,
+      path: options.workingDir
+    }
+  })
+
+  const addedInstalls = (await Promise.all(addedInstallsPromises))
     .filter(_ => !!_)
     .map(_ => _!)
 
@@ -203,7 +204,180 @@ export const addPackages = async (
   }
 }
 
-function replaceContentsOfDir(dirToReplace: string, dirToCopyFrom: string) {
-  emptyDirExcludeNodeModules(dirToReplace)
-  fs.copySync(dirToCopyFrom, dirToReplace)
+async function replaceContentsOfDirectory(
+  destinationDirectory: string,
+  sourceDirectory: string
+) {
+  const itemsInSourceDirectoryExcludingNodeModulesDir = await getAllItemsInDirectory(
+    sourceDirectory,
+    isNodeModulesDirectory
+  )
+
+  const itemsInDestinationDirectoryExcludingNodeModulesDir = await getAllItemsInDirectory(
+    destinationDirectory,
+    isNodeModulesDirectory
+  )
+
+  const itemsInDestinationDirectoryAsMap = convertFileSystemItemArrayToMapKeyedOnRelativePath(
+    itemsInDestinationDirectoryExcludingNodeModulesDir
+  )
+
+  const newItems: FileSystemItem[] = []
+  const changedItems: FileSystemItem[] = []
+  for (const itemInSourceDirectory of itemsInSourceDirectoryExcludingNodeModulesDir) {
+    const itemInDestinationDirectory = itemsInDestinationDirectoryAsMap.get(
+      itemInSourceDirectory.relativePath
+    )
+
+    const itemDiffResults = await diffItems(
+      itemInSourceDirectory,
+      itemInDestinationDirectory
+    )
+
+    switch (itemDiffResults) {
+      case 'changed':
+        changedItems.push(itemInSourceDirectory)
+        break
+      case 'new':
+        newItems.push(itemInSourceDirectory)
+        break
+      case 'same':
+        break
+    }
+  }
+
+  const itemsInSourceDirectoryAsMap = convertFileSystemItemArrayToMapKeyedOnRelativePath(
+    itemsInSourceDirectoryExcludingNodeModulesDir
+  )
+  const removedItems: FileSystemItem[] = []
+  for (const itemInDestinationDir of itemsInDestinationDirectoryExcludingNodeModulesDir) {
+    const itemInSourceDirectory = itemsInSourceDirectoryAsMap.get(
+      itemInDestinationDir.relativePath
+    )
+
+    if (itemInSourceDirectory === undefined) {
+      removedItems.push(itemInDestinationDir)
+    }
+  }
+
+  await copyItems(destinationDirectory, newItems)
+
+  await copyItems(destinationDirectory, changedItems)
+
+  await removeItems(removedItems)
+}
+
+interface FileSystemItem {
+  absolutePath: string
+  relativePath: string
+  stats: fs.Stats
+}
+
+async function getAllItemsInDirectory(
+  rootDir: string,
+  ignoreItemFunc: (item: FileSystemItem) => boolean,
+  parentRootDir?: string
+): Promise<FileSystemItem[]> {
+  parentRootDir = parentRootDir || rootDir
+
+  if (!fs.existsSync(rootDir)) {
+    return []
+  }
+
+  const rootDirPathStats = await fs.stat(rootDir)
+  if (!rootDirPathStats.isDirectory()) {
+    throw new Error(
+      `Cannot get items from given path '${rootDir}' because it is not a directory`
+    )
+  }
+
+  const allItemAbsolutePaths: string[] = (await fs.readdir(rootDir)).map(
+    itemPath => path.resolve(rootDir, itemPath)
+  )
+
+  const statsPromises: Promise<fs.Stats>[] = []
+  for (let entry of allItemAbsolutePaths) {
+    const filePath = path.resolve(rootDir, entry)
+    statsPromises.push(fs.stat(filePath))
+  }
+  const allItemStats: fs.Stats[] = await Promise.all(statsPromises)
+
+  const contents: FileSystemItem[] = []
+  for (let i = 0; i < allItemAbsolutePaths.length; i++) {
+    const item = {
+      absolutePath: allItemAbsolutePaths[i],
+      relativePath: path.relative(parentRootDir, allItemAbsolutePaths[i]),
+      stats: allItemStats[i]
+    }
+
+    if (!ignoreItemFunc(item)) {
+      if (item.stats.isDirectory()) {
+        const subDirItems = await getAllItemsInDirectory(
+          item.absolutePath,
+          ignoreItemFunc,
+          parentRootDir
+        )
+        contents.push(...subDirItems)
+      } else {
+        contents.push(item)
+      }
+    }
+  }
+
+  return contents
+}
+
+const isNodeModulesDirectory = (item: FileSystemItem) =>
+  item.stats.isDirectory() &&
+  path.parse(item.absolutePath).base === 'node_modules'
+
+function convertFileSystemItemArrayToMapKeyedOnRelativePath(
+  items: FileSystemItem[]
+): Map<string, FileSystemItem> {
+  return new Map<string, FileSystemItem>(
+    items.map<[string, FileSystemItem]>(item => [item.relativePath, item])
+  )
+}
+
+async function diffItems(
+  itemAtSource: FileSystemItem,
+  itemAtDestination: FileSystemItem | undefined
+): Promise<'changed' | 'new' | 'same'> {
+  if (itemAtDestination !== undefined) {
+    if (
+      itemAtDestination.stats.mtime.getTime() ===
+        itemAtSource.stats.mtime.getTime() &&
+      itemAtDestination.stats.size === itemAtSource.stats.size
+    ) {
+      const contentsForItemAtDestination = await fs.readFile(
+        itemAtDestination.absolutePath
+      )
+      const contentsForItemAtSource = await fs.readFile(
+        itemAtSource.absolutePath
+      )
+
+      if (contentsForItemAtDestination.equals(contentsForItemAtSource)) {
+        return 'same'
+      }
+    }
+
+    return 'changed'
+  }
+
+  return 'new'
+}
+
+async function copyItems(
+  dirToCopyTo: string,
+  items: FileSystemItem[]
+): Promise<void> {
+  const itemsToCopy = items.map(item =>
+    fs.copy(item.absolutePath, path.resolve(dirToCopyTo, item.relativePath))
+  )
+  await Promise.all(itemsToCopy)
+}
+
+async function removeItems(items: FileSystemItem[]): Promise<void> {
+  const removeItemsPromises = items.map(item => fs.remove(item.absolutePath))
+  await Promise.all(removeItemsPromises)
 }

--- a/src/installations.ts
+++ b/src/installations.ts
@@ -38,9 +38,8 @@ export const readInstallationsFile = (): InstallationsFile => {
 export const showInstallations = ({ packages }: { packages: string[] }) => {
   const config = readInstallationsFile()
   Object.keys(config)
-    .filter(
-      packageName =>
-        packages.length ? packages.indexOf(packageName) >= 0 : true
+    .filter(packageName =>
+      packages.length ? packages.indexOf(packageName) >= 0 : true
     )
     .map((name: PackageName) => ({ name, locations: config[name] }))
     .forEach(({ name, locations }) => {
@@ -55,14 +54,13 @@ export const cleanInstallations = async ({
   packages,
   dry
 }: {
-  packages: string[],
+  packages: string[]
   dry: boolean
 }) => {
   const config = readInstallationsFile()
   const installsToRemove = Object.keys(config)
-    .filter(
-      packageName =>
-        packages.length ? packages.indexOf(packageName) >= 0 : true
+    .filter(packageName =>
+      packages.length ? packages.indexOf(packageName) >= 0 : true
     )
     .map((name: PackageName) => ({ name, locations: config[name] }))
     .reduce(

--- a/src/installations.ts
+++ b/src/installations.ts
@@ -131,20 +131,20 @@ export const addInstallations = async (
 export const removeInstallations = async (
   installations: PackageInstallation[]
 ) => {
-  const installationsConfig = readInstallationsFile()
+  const installationsFile = readInstallationsFile()
   let updated = false
   installations.forEach(install => {
-    const packageInstallPaths = installationsConfig[install.name] || []
+    const packageInstallPaths = installationsFile[install.name] || []
     const index = packageInstallPaths.indexOf(install.path)
     if (index >= 0) {
       packageInstallPaths.splice(index, 1)
       updated = true
     }
     if (!packageInstallPaths.length) {
-      delete installationsConfig[install.name]
+      delete installationsFile[install.name]
     }
   })
   if (updated) {
-    await saveInstallationsFile(installationsConfig)
+    await saveInstallationsFile(installationsFile)
   }
 }

--- a/src/installations.ts
+++ b/src/installations.ts
@@ -90,7 +90,7 @@ export const cleanInstallations = async ({
       console.log(`Package ${inst.name}: ${inst.path}`)
     })
     if (!dry) {
-      await removeInstallations(installsToRemove)
+      await removePackageInstallationsFromInstallationsFile(installsToRemove)
     } else {
       console.log(`Dry run.`)
     }
@@ -128,7 +128,7 @@ export const addInstallations = async (
   }
 }
 
-export const removeInstallations = async (
+export const removePackageInstallationsFromInstallationsFile = async (
   installations: PackageInstallation[]
 ) => {
   const installationsFile = readInstallationsFile()

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -23,9 +23,9 @@ export interface PublishPackageOptions {
   signature?: boolean
   knit?: boolean
   force?: boolean
-  changed?: boolean,
+  changed?: boolean
   push?: boolean
-  pushSafe?: boolean,
+  pushSafe?: boolean
   yarn?: boolean
 }
 
@@ -109,7 +109,7 @@ export const publishPackage = async (options: PublishPackageOptions) => {
       installationsToRemove.concat(installationsToRemoveForPkg)
     }
     await removePackageInstallationsFromInstallationsFile(installationsToRemove)
-  }  
+  }
   //await workaroundYarnCacheBug(pkg)
   const publishedPackageDir = join(getStorePackagesDir(), pkg.name, pkg.version)
   const publishedPkg = readPackageManifest(publishedPackageDir)!

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -5,7 +5,7 @@ import { copyPackageToStore } from './copy'
 import {
   PackageInstallation,
   readInstallationsFile,
-  removeInstallations
+  removePackageInstallationsFromInstallationsFile
 } from './installations'
 
 import {
@@ -108,7 +108,7 @@ export const publishPackage = async (options: PublishPackageOptions) => {
       })
       installationsToRemove.concat(installationsToRemoveForPkg)
     }
-    await removeInstallations(installationsToRemove)
+    await removePackageInstallationsFromInstallationsFile(installationsToRemove)
   }  
   //await workaroundYarnCacheBug(pkg)
   const publishedPackageDir = join(getStorePackagesDir(), pkg.name, pkg.version)

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra'
 import { join } from 'path'
 import {
   PackageInstallation,
-  removeInstallations,
+  removePackageInstallationsFromInstallationsFile,
   PackageName
 } from './installations'
 
@@ -118,6 +118,6 @@ export const removePackages = async (
   })
 
   if (!options.retreat) {
-    await removeInstallations(installationsToRemove)
+    await removePackageInstallationsFromInstallationsFile(installationsToRemove)
   }
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,6 +1,9 @@
 import { execSync } from 'child_process'
 import { join } from 'path'
-import { PackageInstallation, removePackageInstallationsFromInstallationsFile } from './installations'
+import {
+  PackageInstallation,
+  removePackageInstallationsFromInstallationsFile
+} from './installations'
 
 import { readLockfile } from './lockfile'
 
@@ -18,7 +21,10 @@ export const updatePackages = async (
 ) => {
   const { workingDir } = options
 
-  const { lockPackages, installationsToRemove } = findPackagesToUpdateOrRemoveFromGivenProjectPath(packages, workingDir);
+  const {
+    lockPackages,
+    installationsToRemove
+  } = findPackagesToUpdateOrRemoveFromGivenProjectPath(packages, workingDir)
 
   const packagesFiles = lockPackages.filter(p => p.file).map(p => p.name)
   await addPackages(packagesFiles, { workingDir: options.workingDir })
@@ -69,7 +75,10 @@ export const updatePackages = async (
   return installationsToRemove
 }
 
-const findPackagesToUpdateOrRemoveFromGivenProjectPath = (packages: string[], workingDir: string) => {
+const findPackagesToUpdateOrRemoveFromGivenProjectPath = (
+  packages: string[],
+  workingDir: string
+) => {
   const lockfile = readLockfile({ workingDir })
 
   let packagesToUpdate: string[] = []

--- a/src/update.ts
+++ b/src/update.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process'
 import { join } from 'path'
 import { PackageInstallation, removePackageInstallationsFromInstallationsFile } from './installations'
 
-import { readLockfile, LockFileConfigV1 } from './lockfile'
+import { readLockfile } from './lockfile'
 
 import { parsePackageName, addPackages, readPackageManifest, values } from '.'
 
@@ -17,9 +17,8 @@ export const updatePackages = async (
   options: UpdatePackagesOptions
 ) => {
   const { workingDir } = options
-  const lockfile = readLockfile({ workingDir })
 
-  const { lockPackages, installationsToRemove } = findPackagesToUpdateOrRemoveFromGivenProjectPath(packages, workingDir, lockfile);
+  const { lockPackages, installationsToRemove } = findPackagesToUpdateOrRemoveFromGivenProjectPath(packages, workingDir);
 
   const packagesFiles = lockPackages.filter(p => p.file).map(p => p.name)
   await addPackages(packagesFiles, { workingDir: options.workingDir })
@@ -70,7 +69,9 @@ export const updatePackages = async (
   return installationsToRemove
 }
 
-const findPackagesToUpdateOrRemoveFromGivenProjectPath = (packages: string[], workingDir: string, lockfile: LockFileConfigV1) => {
+const findPackagesToUpdateOrRemoveFromGivenProjectPath = (packages: string[], workingDir: string) => {
+  const lockfile = readLockfile({ workingDir })
+
   let packagesToUpdate: string[] = []
   let installationsToRemove: PackageInstallation[] = []
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process'
 import { join } from 'path'
-import { PackageInstallation, removeInstallations } from './installations'
+import { PackageInstallation, removePackageInstallationsFromInstallationsFile } from './installations'
 
 import { readLockfile } from './lockfile'
 
@@ -94,7 +94,7 @@ export const updatePackages = async (
   }
 
   if (!options.noInstallationsRemove) {
-    await removeInstallations(installationsToRemove)
+    await removePackageInstallationsFromInstallationsFile(installationsToRemove)
   }
   return installationsToRemove
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -22,14 +22,16 @@ export const updatePackages = async (
   const { workingDir } = options
 
   const {
-    lockPackages,
+    lockfileInfoForPackagesToUpdate,
     installationsToRemove
   } = findPackagesToUpdateOrRemoveFromGivenProjectPath(packages, workingDir)
 
-  const packagesFiles = lockPackages.filter(p => p.file).map(p => p.name)
+  const packagesFiles = lockfileInfoForPackagesToUpdate
+    .filter(p => p.file)
+    .map(p => p.name)
   await addPackages(packagesFiles, { workingDir: options.workingDir })
 
-  const packagesLinks = lockPackages
+  const packagesLinks = lockfileInfoForPackagesToUpdate
     .filter(p => !p.file && !p.link && !p.pure)
     .map(p => p.name)
   await addPackages(packagesLinks, {
@@ -38,14 +40,18 @@ export const updatePackages = async (
     pure: false
   })
 
-  const packagesLinkDep = lockPackages.filter(p => p.link).map(p => p.name)
+  const packagesLinkDep = lockfileInfoForPackagesToUpdate
+    .filter(p => p.link)
+    .map(p => p.name)
   await addPackages(packagesLinkDep, {
     workingDir: options.workingDir,
     linkDep: true,
     pure: false
   })
 
-  const packagesPure = lockPackages.filter(p => p.pure).map(p => p.name)
+  const packagesPure = lockfileInfoForPackagesToUpdate
+    .filter(p => p.pure)
+    .map(p => p.name)
   await addPackages(packagesPure, {
     workingDir: options.workingDir,
     pure: true
@@ -104,7 +110,7 @@ const findPackagesToUpdateOrRemoveFromGivenProjectPath = (
     packagesToUpdate = Object.keys(lockfile.packages)
   }
 
-  const lockPackages = packagesToUpdate.map(name => ({
+  const lockfileInfoForPackagesToUpdate = packagesToUpdate.map(name => ({
     name: lockfile.packages[name].version
       ? name + '@' + lockfile.packages[name].version
       : name,
@@ -114,7 +120,7 @@ const findPackagesToUpdateOrRemoveFromGivenProjectPath = (
   }))
 
   return {
-    lockPackages: lockPackages,
+    lockfileInfoForPackagesToUpdate: lockfileInfoForPackagesToUpdate,
     installationsToRemove: installationsToRemove
   }
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -19,16 +19,7 @@ export const updatePackages = async (
   const { workingDir } = options
   const lockfile = readLockfile({ workingDir })
 
-  const { packagesToUpdate, installationsToRemove } = findPackagesToUpdateOrRemoveFromGivenProjectPath(packages, workingDir, lockfile);
-
-  const lockPackages = packagesToUpdate.map(name => ({
-    name: lockfile.packages[name].version
-      ? name + '@' + lockfile.packages[name].version
-      : name,
-    file: lockfile.packages[name].file,
-    link: lockfile.packages[name].link,
-    pure: lockfile.packages[name].pure
-  }))
+  const { lockPackages, installationsToRemove } = findPackagesToUpdateOrRemoveFromGivenProjectPath(packages, workingDir, lockfile);
 
   const packagesFiles = lockPackages.filter(p => p.file).map(p => p.name)
   await addPackages(packagesFiles, { workingDir: options.workingDir })
@@ -103,8 +94,17 @@ const findPackagesToUpdateOrRemoveFromGivenProjectPath = (packages: string[], wo
     packagesToUpdate = Object.keys(lockfile.packages)
   }
 
+  const lockPackages = packagesToUpdate.map(name => ({
+    name: lockfile.packages[name].version
+      ? name + '@' + lockfile.packages[name].version
+      : name,
+    file: lockfile.packages[name].file,
+    link: lockfile.packages[name].link,
+    pure: lockfile.packages[name].pure
+  }))
+
   return {
-    packagesToUpdate: packagesToUpdate,
+    lockPackages: lockPackages,
     installationsToRemove: installationsToRemove
   }
 }

--- a/src/yalc.ts
+++ b/src/yalc.ts
@@ -35,7 +35,15 @@ yargs
     builder: () => {
       return yargs
         .default('sig', true)
-        .boolean(['push', 'knit', 'force', 'push-safe', 'sig', 'changed', 'yarn'])
+        .boolean([
+          'push',
+          'knit',
+          'force',
+          'push-safe',
+          'sig',
+          'changed',
+          'yarn'
+        ])
     },
     handler: argv => {
       const folder = argv._[1]

--- a/test/index.ts
+++ b/test/index.ts
@@ -88,7 +88,7 @@ describe('Yalc package manager', function() {
     fs.removeSync(tmpDir)
     fs.copySync(fixtureDir, tmpDir)
   })
-  describe.only('Package publish', function() {
+  describe('Package publish', function() {
     this.timeout(5000)
     before(() => {
       console.time('Package publish')

--- a/test/index.ts
+++ b/test/index.ts
@@ -239,7 +239,7 @@ describe('Yalc package manager', function() {
   })
 
   describe('Update package', () => {
-    const innterNodeModulesFile = join(
+    const innerNodeModulesFile = join(
       projectDir,
       'node_modules',
       values.depPackage,
@@ -259,7 +259,7 @@ describe('Yalc package manager', function() {
           `Expected ${notChangedInnerRootTxtFile} to not be updated because it is the same but fs '${event}' occurred`
         )
       })
-      fs.ensureFileSync(innterNodeModulesFile)
+      fs.ensureFileSync(innerNodeModulesFile)
       await updatePackages([values.depPackage], {
         workingDir: projectDir
       })
@@ -282,11 +282,11 @@ describe('Yalc package manager', function() {
       })
     })
     it('does not remove inner node_modules', () => {
-      checkExists(innterNodeModulesFile)
+      checkExists(innerNodeModulesFile)
     })
   })
 
-  describe('Publish package with --push', () => {
+  describe('Push package updates', () => {
     const rootTxtFileName = 'root-file.txt'
     const newRootTxtFileContents = 'some text in a previous empty file'
 
@@ -294,7 +294,7 @@ describe('Yalc package manager', function() {
       const rootTxtFile = join(depPackageDir, rootTxtFileName)
       await fs.writeFile(rootTxtFile, newRootTxtFileContents)
 
-      const publishPushTimeLabel = 'Package publish --push'
+      const publishPushTimeLabel = 'Push package updates'
       console.time(publishPushTimeLabel)
       await publishPackage({
         workingDir: depPackageDir,
@@ -335,7 +335,7 @@ describe('Yalc package manager', function() {
     })
   })
 
-  describe('Reatreat package', () => {
+  describe('Retreat package', () => {
     before(() => {
       return removePackages([values.depPackage], {
         workingDir: projectDir,
@@ -362,8 +362,8 @@ describe('Yalc package manager', function() {
     })
 
     it('does not update installations file', () => {
-      const installtions = readInstallationsFile()
-      deepEqual(installtions, {
+      const installations = readInstallationsFile()
+      deepEqual(installations, {
         [values.depPackage]: [projectDir]
       })
     })
@@ -412,8 +412,8 @@ describe('Yalc package manager', function() {
     })
 
     it('updates installations file', () => {
-      const installtions = readInstallationsFile()
-      deepEqual(installtions, {})
+      const installations = readInstallationsFile()
+      deepEqual(installations, {})
     })
     it('should remove package from .yalc', () => {
       checkNotExists(join(projectDir, '.ylc', values.depPackage))
@@ -487,8 +487,8 @@ describe('Yalc package manager', function() {
       })
     })
     it('create and updates installations file', () => {
-      const installtions = readInstallationsFile()
-      deepEqual(installtions, {
+      const installations = readInstallationsFile()
+      deepEqual(installations, {
         [values.depPackage]: [projectDir]
       })
     })

--- a/test/index.ts
+++ b/test/index.ts
@@ -252,12 +252,11 @@ describe('Yalc package manager', function() {
       'root-file.txt'
     )
     let fileWatcher: fs.FSWatcher | undefined
+    let fileEvents: string[] = []
 
     before(async () => {
       fileWatcher = fs.watch(notChangedInnerRootTxtFile, event => {
-        throw new Error(
-          `Expected ${notChangedInnerRootTxtFile} to not be updated because it is the same but fs '${event}' occurred`
-        )
+        fileEvents.push(event)
       })
       fs.ensureFileSync(innerNodeModulesFile)
       await updatePackages([values.depPackage], {
@@ -283,6 +282,13 @@ describe('Yalc package manager', function() {
     })
     it('does not remove inner node_modules', () => {
       checkExists(innerNodeModulesFile)
+    })
+    it('does not touch unchanged file', () => {
+      if (fileEvents.length > 0) {
+        throw new Error(
+          `Expected ${notChangedInnerRootTxtFile} to not be updated because it is the same but fs events [${fileEvents.toString()}] occurred`
+        )
+      }
     })
   })
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
-  "extends": ["tslint-config-prettier"],
+  "extends": ["tslint-plugin-prettier", "tslint-config-prettier"],
   "rules": {
+    "prettier": true,
     "no-floating-promises": true,
     "no-unused-expression": true
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,12 +5,10 @@
 "@sindresorhus/df@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@sindresorhus/df/-/df-1.0.1.tgz#c69b66f52f6fcdd287c807df210305dbaf78500d"
-  integrity sha1-xptm9S9vzdKHyAffIQMF2694UA0=
 
 "@sindresorhus/df@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/df/-/df-2.1.0.tgz#d208cf27e06f0bb476d14d7deccd7d726e9aa389"
-  integrity sha1-0gjPJ+BvC7R20U197M19cm6ao4k=
   dependencies:
     execa "^0.2.2"
 
@@ -20,9 +18,9 @@
   dependencies:
     "@types/glob" "*"
 
-"@types/fs-extra@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.2.tgz#7b9b1bbf85962cbe029b5a83c9b530d7c75af3ba"
+"@types/fs-extra@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.4.tgz#b971134d162cc0497d221adde3dbb67502225599"
   dependencies:
     "@types/node" "*"
 
@@ -62,7 +60,6 @@
 ansi-align@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-1.1.0.tgz#2f0c1658829739add5ebb15e6b0c6e3423f016ba"
-  integrity sha1-LwwWWIKXOa3V67FeawxuNCPwFro=
   dependencies:
     string-width "^1.0.1"
 
@@ -89,7 +86,6 @@ argparse@^1.0.7:
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
-  integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -124,7 +120,6 @@ balanced-match@^1.0.0:
 boxen@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-0.6.0.tgz#8364d4248ac34ff0ef1b2f2bf49a6c60ce0d81b6"
-  integrity sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=
   dependencies:
     ansi-align "^1.1.0"
     camelcase "^2.1.0"
@@ -161,7 +156,6 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
-  integrity sha1-MIvur/3ygRkFHvodkyITyRuPkuc=
   dependencies:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
@@ -169,7 +163,6 @@ camelcase-keys@^2.0.0:
 camelcase@^2.0.0, camelcase@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
-  integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
 
 camelcase@^3.0.0:
   version "3.0.0"
@@ -178,7 +171,6 @@ camelcase@^3.0.0:
 capture-stack-trace@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
-  integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
 
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -211,7 +203,6 @@ clean-ts-built@^1.0.0:
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
-  integrity sha1-T6kXw+WclKAEzWH47lCdplFocUM=
 
 cliui@^3.2.0:
   version "3.2.0"
@@ -250,7 +241,6 @@ concat-map@0.0.1:
 configstore@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-2.1.0.tgz#737a3a7036e9886102aa6099e47bb33ab1aba1a1"
-  integrity sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=
   dependencies:
     dot-prop "^3.0.0"
     graceful-fs "^4.1.2"
@@ -265,19 +255,16 @@ configstore@^2.0.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 create-error-class@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
-  integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
   dependencies:
     capture-stack-trace "^1.0.0"
 
 cross-spawn-async@^2.1.1:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
-  integrity sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=
   dependencies:
     lru-cache "^4.0.0"
     which "^1.2.8"
@@ -285,7 +272,6 @@ cross-spawn-async@^2.1.1:
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
-  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
   dependencies:
     nice-try "^1.0.4"
     path-key "^2.0.1"
@@ -296,7 +282,6 @@ cross-spawn@^6.0.0:
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
-  integrity sha1-mI3zP+qxke95mmE2nddsF635V+o=
   dependencies:
     array-find-index "^1.0.1"
 
@@ -313,7 +298,6 @@ decamelize@^1.1.1, decamelize@^1.1.2:
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 del@^2.2.2:
   version "2.2.2"
@@ -334,7 +318,6 @@ diff@3.5.0, diff@^3.2.0:
 dir-glob@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
-  integrity sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==
   dependencies:
     arrify "^1.0.1"
     path-type "^3.0.0"
@@ -342,14 +325,12 @@ dir-glob@^2.0.0:
 dot-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
-  integrity sha1-G3CK8JSknJoOfbyteQq6U52sEXc=
   dependencies:
     is-obj "^1.0.0"
 
 duplexer2@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
-  integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
   dependencies:
     readable-stream "^2.0.2"
 
@@ -362,7 +343,6 @@ error-ex@^1.2.0:
 escape-string-applescript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-applescript/-/escape-string-applescript-2.0.0.tgz#760bca838668e408fe5ee52ce42caf7cb46c5273"
-  integrity sha1-dgvKg4Zo5Aj+XuUs5CyvfLRsUnM=
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -386,7 +366,6 @@ esutils@^2.0.2:
 execa@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
-  integrity sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==
   dependencies:
     cross-spawn "^6.0.0"
     get-stream "^3.0.0"
@@ -399,7 +378,6 @@ execa@^0.10.0:
 execa@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.2.2.tgz#e2ead472c2c31aad6f73f1ac956eef45e12320cb"
-  integrity sha1-4urUcsLDGq1vc/GslW7vReEjIMs=
   dependencies:
     cross-spawn-async "^2.1.1"
     npm-run-path "^1.0.0"
@@ -414,7 +392,6 @@ fast-diff@^1.1.1:
 filled-array@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/filled-array/-/filled-array-1.1.0.tgz#c3c4f6c663b923459a9aa29912d2d031f1507f84"
-  integrity sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q=
 
 find-parent-dir@^0.3.0:
   version "0.3.0"
@@ -430,7 +407,6 @@ find-up@^1.0.0:
 fs-extra@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
-  integrity sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
@@ -438,9 +414,9 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -457,12 +433,10 @@ get-caller-file@^1.0.1:
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
-  integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
 
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
-  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
 glob@7.1.2:
   version "7.1.2"
@@ -511,7 +485,6 @@ globby@^5.0.0:
 globby@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
-  integrity sha1-+yzP+UAfhgCUXfral0QMypcrhoA=
   dependencies:
     array-union "^1.0.1"
     dir-glob "^2.0.0"
@@ -523,7 +496,6 @@ globby@^7.1.1:
 got@^5.0.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/got/-/got-5.7.1.tgz#5f81635a61e4a6589f180569ea4e381680a51f35"
-  integrity sha1-X4FjWmHkplifGAVp6k44FoClHzU=
   dependencies:
     create-error-class "^3.0.1"
     duplexer2 "^0.1.4"
@@ -544,7 +516,6 @@ got@^5.0.0:
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.9:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.10"
@@ -590,22 +561,18 @@ ignore-walk@^3.0.1:
 ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
-  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
 ignore@^5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.0.4.tgz#33168af4a21e99b00c5d41cbadb6a6cb49903a45"
-  integrity sha512-WLsTMEhsQuXpCiG173+f3aymI43SXa+fB1rSfbzyP4GkPP+ZFVuO0/3sFUGNBtifisPeDcl/uD/Y2NxZ7xFq4g==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
 indent-string@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
-  integrity sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=
   dependencies:
     repeating "^2.0.0"
 
@@ -623,7 +590,6 @@ inherits@2, inherits@~2.0.3:
 ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
 invert-kv@^1.0.0:
   version "1.0.0"
@@ -648,7 +614,6 @@ is-ci@^1.0.9:
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
-  integrity sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=
   dependencies:
     number-is-nan "^1.0.0"
 
@@ -661,12 +626,10 @@ is-fullwidth-code-point@^1.0.0:
 is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
-  integrity sha1-8vtjpl5JBbQGyGBydloaTceTufQ=
 
 is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
-  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -687,17 +650,14 @@ is-path-inside@^1.0.0:
 is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
-  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
 is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
-  integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
 
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
 is-utf8@^0.2.0:
   version "0.2.1"
@@ -706,12 +666,10 @@ is-utf8@^0.2.0:
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 jest-docblock@^21.0.0:
   version "21.2.0"
@@ -731,7 +689,6 @@ js-yaml@^3.7.0:
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
-  integrity sha1-NzaitCi4e72gzIO1P6PWM6NcKug=
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -744,21 +701,18 @@ jsonfile@^4.0.0:
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
-  integrity sha1-QIhDO0azsbolnXh4XY6W9zugJDk=
   optionalDependencies:
     graceful-fs "^4.1.9"
 
 latest-version@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-2.0.0.tgz#56f8d6139620847b8017f8f1f4d78e211324168b"
-  integrity sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=
   dependencies:
     package-json "^2.0.0"
 
 lazy-req@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/lazy-req/-/lazy-req-1.1.0.tgz#bdaebead30f8d824039ce0ce149d4daa07ba1fac"
-  integrity sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -779,7 +733,6 @@ load-json-file@^1.0.0:
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
-  integrity sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=
   dependencies:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
@@ -787,12 +740,10 @@ loud-rejection@^1.0.0:
 lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
-  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
 lru-cache@^4.0.0:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.4.tgz#51cc46e8e6d9530771c857e24ccc720ecdbcc031"
-  integrity sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^3.0.2"
@@ -800,12 +751,10 @@ lru-cache@^4.0.0:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
-  integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
 
 meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
-  integrity sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=
   dependencies:
     camelcase-keys "^2.0.0"
     decamelize "^1.1.2"
@@ -863,7 +812,6 @@ mocha@^5.2.0:
 mount-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mount-point/-/mount-point-3.0.0.tgz#665cb9edebe80d110e658db56c31d0aef51a8f97"
-  integrity sha1-Zly57evoDREOZY21bDHQrvUaj5c=
   dependencies:
     "@sindresorhus/df" "^1.0.1"
     pify "^2.3.0"
@@ -876,12 +824,10 @@ ms@2.0.0:
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
-  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
-  integrity sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=
 
 normalize-package-data@^2.3.2:
   version "2.3.5"
@@ -895,7 +841,6 @@ normalize-package-data@^2.3.2:
 normalize-package-data@^2.3.4:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
-  integrity sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==
   dependencies:
     hosted-git-info "^2.1.4"
     is-builtin-module "^1.0.0"
@@ -920,14 +865,12 @@ npm-packlist@^1.1.12:
 npm-run-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
-  integrity sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=
   dependencies:
     path-key "^1.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
-  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
 
@@ -958,12 +901,10 @@ os-locale@^1.4.0:
 os-tmpdir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 osenv@^0.1.0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
-  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
@@ -971,22 +912,18 @@ osenv@^0.1.0:
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
 p-map@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
-  integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
 
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 package-json@^2.0.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-2.4.0.tgz#0d15bd67d1cbbddbb2ca222ff2edb86bcb31a8bb"
-  integrity sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=
   dependencies:
     got "^5.0.0"
     registry-auth-token "^3.0.1"
@@ -1016,12 +953,10 @@ path-is-inside@^1.0.1:
 path-key@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
-  integrity sha1-XVPVeAGWRsDWiADbThRua9wqx68=
 
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
-  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
 path-parse@^1.0.5:
   version "1.0.6"
@@ -1038,7 +973,6 @@ path-type@^1.0.0:
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
-  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
   dependencies:
     pify "^3.0.0"
 
@@ -1049,7 +983,6 @@ pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
 pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
-  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
 pinkie-promise@^2.0.0, pinkie-promise@^2.0.1:
   version "2.0.1"
@@ -1064,7 +997,6 @@ pinkie@^2.0.0:
 prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
-  integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
 prettier@^1.14.2:
   version "1.14.2"
@@ -1073,17 +1005,14 @@ prettier@^1.14.2:
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
-  integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 rc@^1.0.1, rc@^1.1.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
   dependencies:
     deep-extend "^0.6.0"
     ini "~1.3.0"
@@ -1093,7 +1022,6 @@ rc@^1.0.1, rc@^1.1.6:
 read-all-stream@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/read-all-stream/-/read-all-stream-3.1.0.tgz#35c3e177f2078ef789ee4bfafa4373074eaef4fa"
-  integrity sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=
   dependencies:
     pinkie-promise "^2.0.0"
     readable-stream "^2.0.0"
@@ -1116,7 +1044,6 @@ read-pkg@^1.0.0:
 readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
-  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -1129,7 +1056,6 @@ readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5:
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
-  integrity sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
@@ -1137,7 +1063,6 @@ redent@^1.0.0:
 registry-auth-token@^3.0.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
-  integrity sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==
   dependencies:
     rc "^1.1.6"
     safe-buffer "^5.0.1"
@@ -1145,14 +1070,12 @@ registry-auth-token@^3.0.1:
 registry-url@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
-  integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
   dependencies:
     rc "^1.0.1"
 
 repeating@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
-  integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
 
@@ -1179,19 +1102,16 @@ rimraf@^2.2.8:
 run-applescript@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-3.2.0.tgz#73fb34ce85d3de8076d511ea767c30d4fdfc918b"
-  integrity sha512-Ep0RsvAjnRcBX1p5vogbaBdAGu/8j/ewpvGqnQYunnLd9SM0vWcPJewPKNnWFggf0hF0pwIgwV5XK7qQ7UZ8Qg==
   dependencies:
     execa "^0.10.0"
 
 safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 semver-diff@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
-  integrity sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=
   dependencies:
     semver "^5.0.3"
 
@@ -1202,7 +1122,6 @@ semver-diff@^2.0.0:
 semver@^5.0.3, semver@^5.1.0, semver@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
-  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
 semver@^5.3.0:
   version "5.5.1"
@@ -1215,29 +1134,24 @@ set-blocking@^2.0.0:
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
-  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
   dependencies:
     shebang-regex "^1.0.0"
 
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
-  integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
 slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
-  integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -1268,7 +1182,6 @@ string-width@^1.0.1, string-width@^1.0.2:
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -1287,19 +1200,16 @@ strip-bom@^2.0.0:
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
-  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
 strip-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
-  integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
   dependencies:
     get-stdin "^4.0.1"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 supports-color@5.4.0:
   version "5.4.0"
@@ -1320,12 +1230,10 @@ supports-color@^5.3.0:
 timed-out@^3.0.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-3.1.3.tgz#95860bfcc5c76c277f8f8326fd0f5b2e20eba217"
-  integrity sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=
 
 trash-cli@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/trash-cli/-/trash-cli-1.4.0.tgz#3288d890c824a5cc978a6c448a9f329b06be069d"
-  integrity sha1-MojYkMgkpcyXimxEip8ymwa+Bp0=
   dependencies:
     meow "^3.7.0"
     trash "^4.0.0"
@@ -1334,7 +1242,6 @@ trash-cli@^1.4.0:
 trash@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/trash/-/trash-4.3.0.tgz#6ebeecdea4d666b06e389b47d135ea88e1de5075"
-  integrity sha512-f36TKwIaBiXm63xSrn8OTNghg5CYHBsFVJvcObMo76LRpgariuRi2CqXQHw1VzfeximD0igdGaonOG6N760BtQ==
   dependencies:
     escape-string-applescript "^2.0.0"
     fs-extra "^0.30.0"
@@ -1349,7 +1256,6 @@ trash@^4.0.0:
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
 
 ts-clean-built@^1.0.0:
   version "1.0.0"
@@ -1399,7 +1305,6 @@ tsutils@^2.27.2:
 typescript@^3.2.0-rc:
   version "3.2.0-rc"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.0-rc.tgz#7c3816f1c761b096f4f1712382e872f4da8f263e"
-  integrity sha512-RgKDOpEdbU9dAkB4TzxWy46wiyNUKQo0NM0bB7WfvEFw50yu046ldQXpOUYMUTLIAHnToOCtHsu39MYE8o6NCw==
 
 universalify@^0.1.0:
   version "0.1.1"
@@ -1408,12 +1313,10 @@ universalify@^0.1.0:
 unzip-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
-  integrity sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=
 
 update-notifier@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-1.0.3.tgz#8f92c515482bd6831b7c93013e70f87552c7cf5a"
-  integrity sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=
   dependencies:
     boxen "^0.6.0"
     chalk "^1.0.0"
@@ -1427,7 +1330,6 @@ update-notifier@^1.0.2:
 url-parse-lax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
-  integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
   dependencies:
     prepend-http "^1.0.1"
 
@@ -1440,17 +1342,14 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-  integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
 
 uuid@^3.1.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
@@ -1466,14 +1365,12 @@ which-module@^1.0.0:
 which@^1.2.8, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
 widest-line@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-1.0.0.tgz#0c09c85c2a94683d0d7eaf8ee097d564bf0e105c"
-  integrity sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=
   dependencies:
     string-width "^1.0.1"
 
@@ -1490,7 +1387,6 @@ wrappy@1:
 write-file-atomic@^1.1.2:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
-  integrity sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
@@ -1499,14 +1395,12 @@ write-file-atomic@^1.1.2:
 xdg-basedir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-2.0.0.tgz#edbc903cc385fc04523d966a335504b5504d1bd2"
-  integrity sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=
   dependencies:
     os-homedir "^1.0.0"
 
 xdg-trashdir@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/xdg-trashdir/-/xdg-trashdir-2.1.1.tgz#59a60aaf8e6f9240c1daed9a0944b2f514c27d8e"
-  integrity sha512-KcVhPaOu2ZurYNHSRTf1+ZHORkTZGCQ+u0JHN17QixRISJq4pXOnjt/lQcehvtHL5QAKhSzKgyjrcNnPdkPBHA==
   dependencies:
     "@sindresorhus/df" "^2.1.0"
     mount-point "^3.0.0"
@@ -1521,7 +1415,6 @@ y18n@^3.2.1:
 yallist@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
-  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
 yargs-parser@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,6 +720,10 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -998,9 +1002,9 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
-prettier@^1.14.2:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
+prettier@^1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.2.tgz#d31abe22afa4351efa14c7f8b94b58bb7452205e"
 
 process-nextick-args@~2.0.0:
   version "2.0.0"
@@ -1268,15 +1272,16 @@ tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
-tslint-config-prettier@^1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.15.0.tgz#76b9714399004ab6831fdcf76d89b73691c812cf"
+tslint-config-prettier@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.16.0.tgz#4627d0e2639554d89210e480093c381b5186963f"
 
-tslint-plugin-prettier@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz#7eb65d19ea786a859501a42491b78c5de2031a3f"
+tslint-plugin-prettier@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslint-plugin-prettier/-/tslint-plugin-prettier-2.0.1.tgz#95b6a3b766622ffc44375825d7760225c50c3680"
   dependencies:
     eslint-plugin-prettier "^2.2.0"
+    lines-and-columns "^1.1.6"
     tslib "^1.7.1"
 
 tslint@^5.11.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,7 +513,7 @@ got@^5.0.0:
     unzip-response "^1.0.2"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.9:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
 


### PR DESCRIPTION
This fixes https://github.com/whitecolor/yalc/issues/34

Looks like a lot of changes but for the most part just moving code around and renaming stuff, probably easier to review if you look at each commit one at at time (I try and make each commit a logical step to make reviewing easier, up to you though)

The new feature is almost completely in this commit https://github.com/whitecolor/yalc/commit/9b635d3eca1d593ef4ff80f61ff3008ca978fa26

Also had to do some things I am not so sure about
1. This [commit removes graceful-fs](https://github.com/whitecolor/yalc/commit/1cc3447f447553056e487b54af788b5873f615bb) I believe that it is not necessary based on the [docs in fs-extra](https://github.com/jprichardson/node-fs-extra#nodejs-fs-extra) not sure exactly what purpose it is serving though so might be missing something. The `graceful-fs.gracefulify` call does break the promise apis for fs-extra which is the main reason I removed it
2. This [commit removes what I believe to be an unnecessary folder deletion](https://github.com/whitecolor/yalc/commit/99fc8873e0839914c14e410366eddf77051e6d15), right after this delete there is an [fs.ensureSymlinkSync](https://github.com/whitecolor/yalc/commit/99fc8873e0839914c14e410366eddf77051e6d15#diff-636831b11c3a6df21b0ac29b1b90f88dR131) call which does do the right thing in the case of the folder not being a symlink or not existing. My guess is that removing this might break the case of the folder being a symlink and an add call is made to convert it into just a folder. **(edit)** ~Will investigate that~ This hunch was right, removing this code broke the 'replace symlink with a copy of the directory' scenario. With [this commit](https://github.com/whitecolor/yalc/pull/48/commits/693fced2a750c87cdf16bee873f144d79ff6a02b) that scenario is addressed, we just delete the symlink in the case it needs to be replaced with a copy of the directory.

Let me know what you think! Thank you