### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Some documented features might not have been published yet, see the [change log]
 
 ### Publish/push sub-projects
 
-- Useful for monorepos (projects with multiple sub-projects/packages): `yalc publish package-dir will perform publish operation in nested `package` folder of current working dir.
+- Useful for monorepos (projects with multiple sub-projects/packages): `yalc publish package-dir will perform publish operation in nested`package` folder of current working dir.
 
 ### Use with [**Yarn workspaces**](https://yarnpkg.com/lang/en/docs/workspaces/)!
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Why
 
-When developing and authoring multiple packages (private or public), you often find yourself in need of using the latest/WIP versions in other projects that you are working on in your local environment **without publishing those packages to remote registry.** NPM and Yarn address this issue with a similar approach of [symlinked packages](https://docs.npmjs.com/cli/link) (`npm/yarn link`). Though this may work in many cases, it often brings nasty [constraints and problems](https://github.com/yarnpkg/yarn/issues/1761#issuecomment-259706202) with dependency resolution, symlink interoperability between file systems, etc.
+When developing and authoring multiple packages (private or public), you often find yourself in need of using the latest/WIP versions in other projects that you are working on in your local environment **without publishing those packages to the remote registry.** NPM and Yarn address this issue with a similar approach of [symlinked packages](https://docs.npmjs.com/cli/link) (`npm/yarn link`). Though this may work in many cases, it often brings nasty [constraints and problems](https://github.com/yarnpkg/yarn/issues/1761#issuecomment-259706202) with dependency resolution, symlink interoperability between file systems, etc.
 
 ## What
 
@@ -31,7 +31,7 @@ Using Yarn:
 yarn global add yalc
 ```
 
-Some documented features might not has been published yet, see [change log](./CHANGELOG.md).
+Some documented features might not have been published yet, see the [change log](./CHANGELOG.md).
 
 ## Usage
 
@@ -41,8 +41,8 @@ Some documented features might not has been published yet, see [change log](./CH
 - It will copy [all the files that should be published in remote NPM registry](https://docs.npmjs.com/files/package.json#files).
 - It will run `preyalc` or `prepublish` scripts before, and `postyalc` or `postpublish` after. Use `--force` to publish without running scripts.
 - While copying package content, `yalc` calculates the hash signature of all files and, by default, adds this signature to the package manifest `version`. You can disable this by using the `--no-sig` option.
-- You may also use `.yalcignore` to exclude files from publishing to yalc repo, for example files like README.md, etc.
-- `--files` flag will show included files in published package
+- You may also use `.yalcignore` to exclude files from publishing to yalc repo, for example, files like README.md, etc.
+- `--files` flag will show included files in the published package
 - **NB!** Windows users should make sure the `LF` new line symbol is used in published sources; it may be needed for some packages to work correctly (for example, `bin` scripts). `yalc` won't convert line endings for you (because `npm` and `yarn` won't either).
 - **NB!** Note that, if you want to include `.yalc` folder in published package content, you should add `!.yalc` line to `.npmignore`.
 - [Easily propagate package updates everywhere.](#pushing-updates-automatically-to-all-installations)
@@ -51,7 +51,7 @@ Some documented features might not has been published yet, see [change log](./CH
 
 - Run `yalc add my-package` in your dependent project, which
   will copy the current version from the store to your project's `.yalc` folder and inject a `file:.yalc/my-package` dependency into `package.json`.
-- You may specify a particular version with `yalc add my-package@version`. This version will be fixed in `yalc.lock` and during updates it will not affect newly published versions.
+- You may specify a particular version with `yalc add my-package@version`. This version will be fixed in `yalc.lock` and will not affect newly published versions during updates.
 - Use the `--link` option to add a `link:` dependency instead of `file:`.
 - Use the `--dev` option to add yalc package to dev dependencies.
 - With `--pure` flag it will not touch `package.json` file, nor it will touch modules folder, this is useful for example when working with [**Yarn workspaces**](https://yarnpkg.com/lang/en/docs/workspaces/) (read below in _Advanced usage_ section)
@@ -88,23 +88,23 @@ Some documented features might not has been published yet, see [change log](./CH
 - `yalc push` - is a use shortcut command for push operation (which will likely become your primarily used command for publication):
   - `force` options is `true` by default, so it won't run `pre/post` scripts (may change this with `--no-force` flag).
 - `scripts.postupdate` will be executed in host package dir, like while `update` operation.
-- With `--changed` flag yalc will first check if package content has changed before publishing and pushing, it is quick operation, maybe useful for _file watching scenarios_ with pushing on changes.
+- With `--changed` flag yalc will first check if package content has changed before publishing and pushing, it is a quick operation and may be useful for _file watching scenarios_ with pushing on changes.
 
 ### Keep it out of git
 
-- If you are using `yalc'ed` modules temporary while development, first add `.yalc` and `yalc.lock` to `.gitignore`.
-- Use `yalc link`, that won't touch `packages.json`
-- If you use `yalc add` it will change `package.json`, and ads `file:`/`link:` dependencies, if you may want to use `yalc check` in the [precommit hook](https://github.com/typicode/husky) which will check package.json for `yalc'ed` dependencies and exits with error, if you forgot to remove them.
+- If you are using `yalc'ed` modules temporarily during development, first add `.yalc` and `yalc.lock` to `.gitignore`.
+- Use `yalc link`, that won't touch `package.json`
+- If you use `yalc add` it will change `package.json`, and ads `file:`/`link:` dependencies, if you may want to use `yalc check` in the [precommit hook](https://github.com/typicode/husky) which will check package.json for `yalc'ed` dependencies and exits with an error if you forgot to remove them.
 
 ### Keep it in git
 
 - You may want to keep shared `yalc'ed` stuff within the projects you are working on and treat it as a part of the project's codebase. This may really simplify management and usage of shared _work in progress_ packages within your projects and help to make things consistent. So, then just do it, keep `.yalc` folder and `yalc.lock` in git.
 - Replace it with published versions from remote repository when ready.
-- **NB!** - standard non-code files like `README`, `LICENCE` etc. will be included also, so you may want to excluded them in `.gitignore` with a line like `**/.yalc/**/*.md` or you may use `.yalcignore` not to include those files in package content.
+- **NB!** - standard non-code files like `README`, `LICENCE` etc. will be included also, so you may want to exclude them in `.gitignore` with a line like `**/.yalc/**/*.md` or you may use `.yalcignore` not to include those files in package content.
 
 ### Publish/push sub-projects
 
-- Useful for monorepos (projects with multiple sub-projects/packages): `yalc publish package-dir will perform publish operation in nested`package` folder of current working dir.
+- Useful for monorepos (projects with multiple sub-projects/packages): `yalc publish package-dir will perform publish operation in nested `package` folder of current working dir.
 
 ### Use with [**Yarn workspaces**](https://yarnpkg.com/lang/en/docs/workspaces/)!
 
@@ -116,7 +116,7 @@ If you want to override default pure behavior use `--no-pure` flag.
 
 ### Clean up installations file
 
-- While working with yalc for some time on the dev machine you may face the situation when you have locations where you added yalc'ed packages being removed from file system, and this will cause some warning messages when yalc will try to push package to removed location. To get rid of such messages there in an explicit command for this `yalc installations clean [package]`.
+- While working with yalc for some time on the dev machine you may face the situation when you have locations where you added yalc'ed packages being removed from file system, and this will cause some warning messages when yalc will try to push package to removed location. To get rid of such messages, there is an explicit command for this: `yalc installations clean [package]`.
 
 ## Related links
 


### PR DESCRIPTION
This fixes some typos in the documentation.

_`Yalc` is a really nice and very useful plugin, well done and thank you for creating something like this!_