### PR TITLE
Run prepack before `publish`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Some documented features might not have been published yet, see the [change log]
 
 - Run `yalc publish` in your dependency package `my-package`.
 - It will copy [all the files that should be published in remote NPM registry](https://docs.npmjs.com/files/package.json#files).
-- It will run `preyalc` or `prepublish` scripts before, and `postyalc` or `postpublish` after. Use `--force` to publish without running scripts.
+- If your package has one of these lifecycle scripts: `preyalc`, `prepare`, `prepack`, `prepublishOnly`, `prepublish`, it will run before. If your package has one of these: `postyalc` or `postpublish`, it will run after. Use `--force` to publish without running scripts.
 - While copying package content, `yalc` calculates the hash signature of all files and, by default, adds this signature to the package manifest `version`. You can disable this by using the `--no-sig` option.
 - You may also use `.yalcignore` to exclude files from publishing to yalc repo, for example, files like README.md, etc.
 - `--files` flag will show included files in the published package

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export type PackageScripts = Partial<{
   preinstall: string
   postupdate: string
   postpush: string
+  prepack: string
   prepare: string
   install: string
   prepublish: string

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -67,6 +67,7 @@ export const publishPackage = async (options: PublishPackageOptions) => {
     const scriptNames: (keyof PackageScripts)[] = [
       'preyalc',
       'prepare',
+      'prepack',
       'prepublishOnly',
       'prepublish'
     ]


### PR DESCRIPTION
Resolves https://github.com/whitecolor/yalc/issues/92

It looks like the code only runs the first found pre~ script, and the first found post~ script, so I adjusted the wording of the readme to match that. I guess it's probably something that will get fixed in the future, but I think it's worth it to document the behavior. 