### PR TITLE
Add types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "yalc": "src/yalc.js"
   },
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc",
     "clean": "trash **/*.js **/*.js.map **/*.d.ts **/*.log !**/node_modules/**",


### PR DESCRIPTION
This allows the types in the repo to be consumed by third parties.