### PR TITLE
Update copyDirSafe to accept a cache object rather than storing itself

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -93,7 +93,9 @@ export const addPackages = async (
     }
     const destYalcCopyDir = join(workingDir, values.yalcPackagesFolder, name)
 
-    await copyDirSafe(storedPackageDir, destYalcCopyDir)
+    const storeCache = {}
+
+    await copyDirSafe(storedPackageDir, destYalcCopyDir, storeCache)
 
     let replacedVersion = ''
     if (doPure) {
@@ -121,7 +123,7 @@ export const addPackages = async (
       if (options.link || options.linkDep) {
         ensureSymlinkSync(destYalcCopyDir, destModulesDir, 'junction')
       } else {
-        await copyDirSafe(storedPackageDir, destModulesDir)
+        await copyDirSafe(storedPackageDir, destModulesDir, storeCache)
       }
 
       if (!options.link) {

--- a/src/sync-dir.ts
+++ b/src/sync-dir.ts
@@ -4,6 +4,15 @@ import { resolve } from 'path'
 import * as fs from 'fs-extra'
 import { getFileHash } from './copy'
 
+type Cache = {
+  [dir: string]: {
+    glob: string[]
+    files: {
+      [file: string]: { stat: fs.Stats; hash: string }
+    }
+  }
+}
+
 const NODE_MAJOR_VERSION = parseInt(
   (<any>process).versions.node.split('.').shift(),
   10
@@ -16,15 +25,6 @@ if (NODE_MAJOR_VERSION >= 8 && NODE_MAJOR_VERSION < 10) {
 }
 
 const globP = util.promisify(glob)
-
-const cache: {
-  [dir: string]: {
-    glob: string[]
-    files: {
-      [file: string]: { stat: fs.Stats; hash: string }
-    }
-  }
-} = {}
 
 const makeListMap = (list: string[]) => {
   return list.reduce(
@@ -43,7 +43,11 @@ const theSameStats = (srcStat: fs.Stats, destStat: fs.Stats) => {
   )
 }
 
-export const copyDirSafe = async (srcDir: string, destDir: string) => {
+export const copyDirSafe = async (
+  srcDir: string,
+  destDir: string,
+  cache: Cache = {}
+) => {
   const ignore = '**/node_modules/**'
   const dot = true
   const nodir = true


### PR DESCRIPTION
This fixes #103 where a package cannot be added or pushed multiple times in a long running node process since the initial package store cache is always used.

The intention of the cache is to cache the store across the two calls in add.ts, which this modification achieves.