### PR TITLE
chore: replace `user-home` for built-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "glob": "^7.1.4",
     "ignore": "^5.0.4",
     "npm-packlist": "^1.4.1",
-    "user-home": "^2.0.0",
     "yargs": "^7.1.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import { execSync, ExecSyncOptions } from 'child_process'
 import * as fs from 'fs-extra'
+import { homedir } from 'os'
 import { join } from 'path'
 import { PackageName } from './installations'
 
-const userHome = require('user-home')
+const userHome = homedir()
 
 export const values = {
   myNameIs: 'yalc',


### PR DESCRIPTION
Node's [`os.homedir`](https://nodejs.org/api/os.html#os_os_homedir) has been available since v2.3.0.

The `user-home` dependency you were using ([which relied on `os-homedir`](https://github.com/sindresorhus/user-home/blob/master/index.js#L2)) was originally meant as polyfill and has been deprecated for a looooong time now. :)