### PR TITLE
fix(publish): adds quotes around workingDir

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -47,7 +47,7 @@ export const publishPackage = async (options: PublishPackageOptions) => {
     return
   }
   const scripts = pkg.scripts || ({} as PackageScripts)
-  const changeDirCmd = 'cd ' + options.workingDir + ' && '
+  const changeDirCmd = 'cd "' + options.workingDir + '" && '
   const scriptRunCmd =
     !options.force && pkg.scripts
       ? changeDirCmd + getPackageManager(workingDir) + ' run '


### PR DESCRIPTION
running 
```bash
yalc publish
``` 
from a path containing spaces, eg `/Users/me/Cool Project/blah` was failing with an error:
```
/bin/sh: line 0: cd: /Users/me/Cool: No such file or directory
```
Adding quotes around `options.workingDir` fixes it for me, maybe others had this issue too?
