### PR TITLE
Surface STDOUT/STDERR from child processes

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -13,6 +13,7 @@ import {
   writePackageManifest,
   readSignatureFile,
   runOrWarnPackageManagerInstall,
+  execLoudOptions,
 } from '.'
 
 import { getPackageManager, pmRunScriptCmd } from './pm'
@@ -74,7 +75,10 @@ export const addPackages = async (
     const scriptCmd = localPkg.scripts?.[script as keyof PackageScripts]
     if (scriptCmd) {
       console.log(`Running ${script} script: ${scriptCmd}`)
-      execSync(`${pmRunScriptCmd[pm]} ${script}`, { cwd: workingDir })
+      execSync(`${pmRunScriptCmd[pm]} ${script}`, {
+        cwd: workingDir,
+        ...execLoudOptions,
+      })
     }
   }
 

--- a/src/check.ts
+++ b/src/check.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra'
 import { execSync } from 'child_process'
 import * as path from 'path'
 import { join } from 'path'
-import { PackageManifest, values } from '.'
+import { execLoudOptions, PackageManifest, values } from '.'
 
 export type CheckOptions = {
   workingDir: string
@@ -33,11 +33,13 @@ export function checkManifest(options: CheckOptions) {
   if (options.commit) {
     execSync(stagedChangesCmd, {
       cwd: options.workingDir,
+      ...execLoudOptions,
     })
       .toString()
       .trim()
     execSync(stagedChangesCmd, {
       cwd: options.workingDir,
+      ...execLoudOptions,
     })
       .toString()
       .trim()

--- a/src/pm.ts
+++ b/src/pm.ts
@@ -1,6 +1,7 @@
 import { execSync, ExecSyncOptions } from 'child_process'
 import * as fs from 'fs-extra'
 import { join } from 'path'
+import { execLoudOptions } from '.'
 
 type PackageMangerName = 'yarn' | 'npm' | 'pnpm'
 
@@ -47,8 +48,6 @@ export const getPackageManagerInstallCmd = (cwd: string) =>
   pmInstallCmd[getPackageManager(cwd)]
 
 export const isYarn = (cwd: string) => getPackageManager(cwd) === 'yarn'
-
-const execLoudOptions = { stdio: 'inherit' } as ExecSyncOptions
 
 export const runOrWarnPackageManagerInstall = (
   workingDir: string,

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -48,7 +48,10 @@ export const publishPackage = async (options: PublishPackageOptions) => {
     const scriptCmd = pkg.scripts?.[script]
     if (scriptCmd) {
       console.log(`Running ${script} script: ${scriptCmd}`)
-      execSync(`${pmRunScriptCmd[pm]} ${script}`, { cwd: workingDir })
+      execSync(`${pmRunScriptCmd[pm]} ${script}`, {
+        cwd: workingDir,
+        ...execLoudOptions,
+      })
     }
   }
 


### PR DESCRIPTION
This passes along `stdio: 'inherit'` to all instances where `child_process.execSync` is called, so all STDOUT and STDERR from the child process is displayed.

Without this, the only feedback given, e.g. when a script fails, is `Error: Command failed: yarn preyalcpublish`.
