### PR TITLE
Fix "quiet" command line argument typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If you want to override default pure behavior use `--no-pure` flag.
 
 ### Control output
 
-- Use `--quite` to fully disable output (except of errors). Use `--no-colors` to disable colors.
+- Use `--quiet` to fully disable output (except of errors). Use `--no-colors` to disable colors.
 
 ## Related links
 

--- a/src/yalc.ts
+++ b/src/yalc.ts
@@ -30,7 +30,7 @@ const getVersionMessage = () => {
 
 makeConsoleColored()
 
-if (process.argv.includes('--quite')) {
+if (process.argv.includes('--quiet') || process.argv.includes('--quite')) {
   disabledConsoleOutput()
 }
 


### PR DESCRIPTION
Just noticed this while reading through the documentation. I kept the old argument so that it would maintain backwards compatibility.